### PR TITLE
Removed 'allowBackup' property

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
-group='com.github.bhargavms'
+group='com.github.emanzanoaxa'
 
 android {
     compileSdkVersion 24
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion 11
         targetSdkVersion 24
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.0.1"
     }
     buildTypes {
         release {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
 group='com.github.emanzanoaxa'
+version="1.0.1"
 
 android {
     compileSdkVersion 24

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
     package="com.bhargavms.dotloader">
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
 


### PR DESCRIPTION
Removed 'allowBackup' property from library manifest to prevent errors on manifest merging with projects.
